### PR TITLE
fixed wrong file extension bug (bug where all model's file extension was safetensors), also fixed the bug where python requests was unable to parse chinese characters by switching from latin-1 to utf-8

### DIFF
--- a/test/batchtest1.txt
+++ b/test/batchtest1.txt
@@ -8,3 +8,4 @@ https://civitai.com/models/197273?modelVersionId=221861,
 https://civitai.com/models/68415/25d-style-lora,
 https://civitai.com/api/download/models/128641,
 https://civitai.com/api/download/models/131654,
+https://civitai.com/models/185146/shizuka


### PR DESCRIPTION
#4 
- Program now works with other file extensions. It would always choose the default file extension of a specific model's version.

#5 
- Program now is able to download VAE too.. Not sure why but after changing the file extensions, it is now able to download the following two albeit disgarding the format=x query
```
https://civitai.com/api/download/models/128641?type=Model&format=PickleTensor
https://civitai.com/api/download/models/131654?type=Model&format=SafeTensor
```
